### PR TITLE
Moving unused package dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
       "reactify"
     ]
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "aws-sdk-apis": "*",
     "body-parser": "^1.9.2",
     "canvas": "*",
@@ -24,11 +25,9 @@
     "node-twitter": "*",
     "node-twitter-api": "*",
     "p3p": "0.0.2",
+    "react-tools": "^0.13.3",
     "supervisor": "*",
     "temp": "*"
-  },
-  "devDependencies": {
-    "react-tools": "^0.13.3"
   },
   "scripts": {
     "jsx": "jsx --no-cache-dir -x jsx ./widget ./js",


### PR DESCRIPTION
WRIO-InternetOS is npm package
Titter-WRIO-App is npm package

WRIO-InternetOS depends on Titter-WRIO-App.

How it will be:
inside WRIO-InternetOS
```npm install titter-wrio-app```

this will install only dependencies from "dependencies" section of Plus-WRIO-App/package.json

So we could put server side dependencies to devDependencies to avoid overhead.

This changes don't change TravisCI build because it use:
```npm install```
will install both "dependencies" and "devDependencies")